### PR TITLE
OEP-54: Core Contributor Program

### DIFF
--- a/oeps/processes/oep-0054-core-contributors.rst
+++ b/oeps/processes/oep-0054-core-contributors.rst
@@ -1,0 +1,283 @@
+===========================
+OEP-54: Core Contributors
+===========================
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-54 <oep-0054-core-contributors>`
+   * - Title
+     - Core Contributor Program
+   * - Last Modified
+     - 2022-01-26
+   * - Authors
+     - Sarina Canelake <sarina@tcril.org>
+   * - Arbiter
+     - Xavier Antoviaque <xavier@opencraft.com>
+   * - Status
+     - Under Review
+   * - Type
+     - Process
+   * - Created
+     - 2021-12-20
+   * - Review Period
+     - 2022-01-05 - 2022-02-01
+
+.. contents::
+   :local:
+   :depth: 3
+
+
+Abstract
+========
+
+This document defines the Core Contributor (CC) Program, a program that grants
+rights to individuals in the Open edX community that allow them to actively
+participate in defining and deciding the direction of the platform.
+
+Motivation
+==========
+
+The Open edX project benefits from a wide variety of perspectives at all levels.
+Having an inclusive group of people participating in the project and helping to
+shape its direction will lead to a more vibrant platform ecosystem that fosters
+stronger innovative collaboration within the Open edX community, increased
+velocity that accelerates platform advancement, and increased capacity to own
+and maintain all aspects of the platform.
+
+Specification
+=============
+
+The Open edX Core Contributor Program grants specific types of access rights to
+Open edX community members, which enables them to further the development and
+adoption of the Open edX platform. CCs earn these rights by sustained, active
+participation in the Open edX community and by following the “3 Cs”: Commitment,
+Conduct, Caliber. Core Contributors follow the `Code of Conduct
+<https://open.edx.org/code-of-conduct/>`_, are respectful of other community
+members, are polite and welcoming to all in the community, and have shown the
+ability to deliver high quality work over time.
+
+Core Contributor Roles
+----------------------
+
+There are many contributors to the Open edX platform that participate in a
+variety of ways - writing code for the Open edX software, translating the
+project, performing Quality Assurance tasks, participating in the Marketing
+working group, writing documentation, and more. At the time of writing we have
+identified the following roles: Project Manager, Translation Lead, Code
+Contributors, Forum Moderators, UI/UX Designers, Marketing Team Members,
+Documentation Writers, QA, and Product Managers.
+
+All CCs are granted some Rights to the project as part of participating - the
+ability to merge code, the final say on marketing copy, etc. In exchange for
+these Rights to contribute, we ask that CCs abide by their Responsibilities. For
+more on the CC roles, and Rights & Responsibilities, see:
+
+- `Core Contributor Role Definitions
+  <https://openedx.atlassian.net/wiki/spaces/COMM/pages/2759460357/Core+Contributor+Role+Definitions>`_
+- `Core Contributor Rights & Responsibilities
+  <https://openedx.atlassian.net/wiki/spaces/COMM/pages/2952003698/Core+Contributor+Rights+Responsibilities+excluding+code+contributors>`_
+- `Code Committer Rights & Responsibilities
+  <https://openedx.atlassian.net/wiki/spaces/COMM/pages/1529675973/Rights+Responsibilities+for+Code+Contributors>`_
+
+Note that roles vary in what they need from members; the wiki will be the most
+up to date source of what each role entails and what types of commitments are
+expected.
+
+.. _program administration:
+
+Core Contributor Program Administration
+---------------------------------------
+
+The Core Contributor Program is administered by The Center for Re-imagining
+Learning (tCRIL). One or more persons at tCRIL (the "Program administrator(s)")
+work with the community to make sure the program runs smoothly: this entails
+facilitating communication amongst community members, `selecting new members`_,
+and ensuring that existing members renew their commitment to the community and
+abide by the Code of Conduct. Program administrators are empowered to monitor
+Core Contributor conduct, particularly whether they follow the "3 Cs"
+(Commitment, Conduct, Caliber), and may issue reminders, suspensions, and even
+removal from the Program. `Contact the Program Administrators`_ as needed.
+
+The tCRIL administrator(s) are the point people for making sure that needed
+agreements are signed. Formost, this is a Program Agreement between the CC and
+tCRIL (sent to you by a Program Administrator). Additionally, if the CC commits
+code to a GitHub repo, a CLA is needed (which should have been signed when you
+made your first PR). Finally, for new companies or organizations joining the
+community, an Entity Contributor Agreement most be signed (please communicate
+with a Program Administrator about this).
+
+We are additionally asking that all companies and teams joining the Open edX
+community sign the `Revised Declaration of Commitment to the Core Contributor
+Program <https://openedx.atlassian.net/wiki/spaces/COMM/pages/3216900524>`_ to
+demonstrate that they are willing to engage with and commit resources to the
+Open edX project. We encourage a commitment of 20 hours/month from each of an
+organization's Core Contributors, however, we recognize that circumstances
+differ and a different commitment may be more appropriate. Before signing the
+agreement, please `Contact the Program Administrators`_ to discuss.
+
+Questions about the Program can be directed to the tCRIL administrator(s) via
+the ``#core-contributors`` Slack room in the `Open edX Slack
+<https://openedx.slack.com/>`_.
+
+.. _selecting new members:
+
+Adding New Core Contributors
+----------------------------
+
+New Core Contributors are determined via a nomination process - CCs may nominate
+new members, or existing community members may put themselves forward for a
+role.
+
+Current CCs should always be on the lookout for contributors who demonstrate the
+"3 Cs" (Commitment, Conduct, and Caliber), follow the `Code of Conduct
+<https://open.edx.org/code-of-conduct/>`_, are respectful of other community
+members, are polite and welcoming to all in the community, and have been an
+overall active community member for some time. When a person like this comes to
+the attention of a CC, the CC should reach out and ask if that person would like
+to be nominated as a CC.
+
+Community members who feel they fit these criteria listed above should feel
+empowered to nominate themselves, as well.
+
+Note that when a new Core Contributor role is being defined and piloted,
+however, nominations should proceed only once the Program Administrator is
+confident that new Core Contributors in that role can be supported. `Contact the
+Program Administrators`_ when there is any uncertainty around the status of the
+role.
+
+At times, the Core Contributor program may suspend accepting new members, when
+there is insufficient support for additional people in a given role. Program
+Administrators will indicate this by posting in the `Core Contributors
+discussion category
+<https://discuss.openedx.org/c/working-groups/core-contributors/36>`_.
+
+New Core Contributor Nomination Process
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The process for nomination is as follows:
+
+#. An existing CC ("sponsor") chooses to nominate a community member ("sponsored
+   candidate") for a new CC position (if they already hold a CC position, they
+   should still be nominated for a new role). A current community member
+   ("organic candidate") may also decide to put themselves forth for nomination.
+
+#. The sponsor or organic candidate posts a new public nomination thread on
+   Discourse, in the `Core Contributor discussion space
+   <https://discuss.openedx.org/c/working-groups/core-contributors/36>`_.
+
+   #. This post introduces the candidate, describes in a few paragraphs why they
+      are suited to join the program, and provides links to examples of previous
+      Open edX work (for example, pull requests).
+   
+   #. The post should also indicate the candidate's expected commitment to
+      contribution - if the candidate is part of an organization, this should be
+      covered as part of the organization's signature to the Declaration of
+      Commitment to the Core Contributor Program, as covered in the `program
+      administration`_ section.
+   
+   #. Finally, the post must mention the date when the comment period ends,
+      which is at least 2 weeks from the start of the thread. Please be mindful
+      of times such as holiday breaks where people may have limited
+      availability.
+
+#. The sponsor or organic candidate posts a link to the Discourse post in the
+   ``#core-contributors`` Slack room, as well as any other Slack rooms relevant
+   to the CC role being discussed (for example, repo-specific rooms for coding
+   contributors, translation team rooms, etc). **The messages must indicate the
+   dates of the comment period.**
+
+#. During the comment period, other CCs should weigh in on the thread. As much
+   as possible, posts should conclude with a definitive "yes" or "no" vote.
+
+   #. If anyone has concerns they feel cannot be raised publicly, they should
+      `Contact the Program Administrators`_ to determine how to proceed. The
+      Administrators should discuss the concerns and try to figure out a way the
+      person could post those concerns themselves; if they cannot, the
+      Administrators should post an anonymized version of the concerns on the
+      Discourse thread.
+
+   #. For those leaving a "no" vote: Remember to leave constructive criticism! A
+      "no" vote should be interpreted as "candidate isn't ready yet". In this
+      case, provide some tips as to how they could make it into the program. And
+      please err on the side of leaving that feedback, rather than not replying
+      at all. A good way to deliver this feedback is "Thank you for contributing
+      to the Open edX community. However, I feel you are not quite ready for
+      this role, for <reasons>. Some ways you could address these are <action
+      items>"
+
+#. Over the course of the comment period, the sponsor, sponsored candidate, or
+   organic candidate should respond to all concerns that come in. It may also be
+   necessary to periodically nudge other CCs to respond to the thread.
+
+   #. At any time, the candidate may choose to withdraw from the process. The
+      candidate should leave a note on the thread, and close it if they wish.
+
+#. At the end of the comment period, a candidate is approved if there are at
+   least 5 (five) affirmative "yes" votes, and zero "no" votes.
+
+   #. For candidates coming from an organization, at least one affirmative vote
+      must come from a CC outside of the candidate's org. This is to ensure that
+      core contributors are evaluated on their ability to communicate with the
+      community, outside of their org.
+
+   #. For roles with few existing members, it is encouraged to ask CCs of other
+      roles to help evaluate the candidate.
+
+#. If the candidate is approved, the candidate should proactively work with the
+   Program Administrator to get the access they need for their role.
+
+#. If the candidate has not been approved, the sponsor (or Program
+   Administrator, in the case of organic candidates) should discuss with the
+   candidate what they need to work on to become a CC. We encourage the
+   sponsor/Administrator to help the candidate develop a plan of action so that
+   they can be successful in the future.
+   
+Where Do I Start?
+^^^^^^^^^^^^^^^^^
+
+New community members interested in the Core Contributor program should `get in
+touch with us! <https://open.edx.org/community/connect/>`_ First check out the
+`discussion forums <https://discuss.openedx.org/>`_; there are a lot of
+different categories, and we encourage new members to spend some time in the
+forums, reading through to understand what's going on and jumping in to ask
+questions.  The ``#core-contributors`` room in `Open edX Slack
+<https://openedx.slack.com/>`_ can help guide people towards others working in
+their area(s) of interest. For those joining Slack for the first time, `here's
+an invite <http://openedx-slack-invite.herokuapp.com/>`_.
+
+Existing community members who have a record of contributing to the Open edX
+project should feel free to reach out to `current CCs
+<https://openedx.atlassian.net/wiki/spaces/COMM/pages/3156344833/Current+Open+edX+Core+Contributors>`_
+who have the role they're interested in. Engaging in conversation to see what
+it's like to be that type of CC is invaluable. CCs might even be able to take a
+look at work the community member has done, however, CCs may be pretty
+overloaded, so offense shouldn't be taken if someone doesn't have time at that
+moment to help.
+
+If you don't know where to begin, try `joining a working group
+<https://openedx.atlassian.net/wiki/spaces/COMM/pages/46793351/Working+groups>`_
+- working groups may have tasks you can pick up to start showing off your
+skills. Start participating on the `discussion forums
+<https://discuss.openedx.org/>`_; some working groups have an active presence
+there, and you'll get a chance to hone your Open edX expertise by answering
+questions. And finally, you can find core contributors and ask questions about
+the program and your interests directly either in the `Core Contributors
+discussion category
+<https://discuss.openedx.org/c/working-groups/core-contributors/36>`_ or in the
+``#core-contributors`` room on Slack.
+
+Contact the Program Administrators
+----------------------------------
+
+Questions about the Program can be directed to the tCRIL administrator(s) via
+the ``#core-contributors`` Slack room in the `Open edX Slack
+<https://openedx.slack.com/>`_ or at ``cc-program-admins@tcril.org``.
+
+Change History
+==============
+
+2021-12-20
+----------
+
+* Document created.


### PR DESCRIPTION
This document defines the Core Contributor (CC) Program, a program that grants rights to individuals
in the Open edX community that allow them to actively participate in defining and deciding the
direction of the platform.