### PR TITLE
[OEP-1] Community-based Decision Making for Arbiter Selection

### DIFF
--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -92,9 +92,8 @@ forums, and attempts to build community consensus around the idea.
 Arbiter
 -------
 
-Each OEP also has an Arbiter (as described in `Step 1. Request an Arbiter`_).
-The Arbiter will be chosen by the `edX Architecture Team`_. An Author of an OEP
-cannot concurrently be the Arbiter of that OEP.
+Each OEP also has an Arbiter (as described in `Step 1. Find an Arbiter`_).
+An Author of an OEP cannot concurrently be the Arbiter of that OEP.
 
 The Arbiter will be the person making the final decision on whether the OEP
 should be Accepted, and as such, the Arbiter should be knowledgeable about
@@ -113,15 +112,22 @@ Finally, the Arbiter is responsible for the decision to transfer an OEP if the
 original Authors have become unresponsive (as described in `Transferring OEP
 Ownership`_).
 
-Architecture Team
------------------
+.. _Architecture Group:
 
-The `edX Architecture Team`_ is accountable for assigning Arbiters to incoming
+Architecture Group
+------------------
+
+The Architecture Group is ultimately accountable for assigning Arbiters to incoming
 Draft OEPs and revived OEPs that need a new Arbiter (if the original Arbiter is no
-longer available). The team can also be a resource to help or advise the Arbiter
-with the OEP process.
+longer available). The group can also be a resource to help or advise the
+Arbiter with the OEP process. The group can be found in the `Architecture Group
+Discourse category`_ or the ``#architecture`` channel in the `Open edX Slack`_.
 
-.. _edX Architecture Team: https://openedx.atlassian.net/wiki/spaces/AC/pages/439353453/Architecture+Team
+.. _Architecture Group Discourse category: https://discuss.openedx.org/c/development/architecture/12
+.. _Open edX Slack: http://openedx-slack-invite.herokuapp.com/
+
+*Note: If an architecture or similar working group is created, those details
+should be added here.*
 
 OEP Workflow
 ============
@@ -133,14 +139,28 @@ OEP Workflow
 Submitting an OEP
 -----------------
 
-Step 1. Request an Arbiter
+Step 1. Find an Arbiter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Request an Arbiter from the `edX Architecture Team`_ by emailing
-`arch-team@edx.org`_. This Arbiter will be recorded in the "Arbiter" header on the
-OEP.
+When writing an OEP, you may already have an idea of an Arbiter in mind. If so,
+reach out to that person and ask them; they should have the domain expertise
+needed to be an effective Arbiter and the time to do so. It is best practice for
+the Arbiter to be from a different team or group than the author.
 
-.. _`arch-team@edx.org`: mailto:arch-team@edx.org
+If you're not sure who would make a good Arbiter, you should post in the
+`Architecture Group`_ category on the Discourse forum or the ``#architecture``
+channel in the `Open edX Slack`_; please feel free to participate in the
+discussion and help choose an arbiter you feel you can work with. If you have
+concerns about an arbiter that has been chosen for a particular OEP, please
+share them with the author first and see if you can resolve your concerns
+directly. If you continue to have concerns, please share them in slack or
+Discourse, ideally on the original conversation thread. If you feel you can't
+share concerns publicly, see our `code of conduct`_ for information on getting
+direct assistance.
+
+Once found, this Arbiter will be recorded in the "Arbiter" header on the OEP.
+
+.. _code of conduct: https://openedx.org/code-of-conduct/
 
 Step 2. Create PR for "Draft" OEP
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -300,7 +320,7 @@ A Best Practice OEP may be updated even after it is "Accepted" as it evolves
 over time. A pull request should be created to update the OEP and have it go
 through the `Step 3. Review with Arbiter`_ process. These future edits/updates may
 be made by the original Authors of the OEP or by new Authors. The Arbiter may
-remain the same as before or may be reassigned by the `edX Architecture Team`_.
+remain the same as before or may be reassigned by the `Architecture Group`_.
 
 Updating Architecture and Process OEPs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -310,8 +330,8 @@ the "Accepted" or "Final" state. However, they may be replaced by subsequent OEP
 (OEPs that are replaced are given the status "Replaced".)
 
 The choice of whether an edit to an OEP should be allowed or whether a new OEP
-should be published is up to the Arbiter of the original OEP, or the `edX
-Architecture Team`_ if that Arbiter is no longer available. However, as a
+should be published is up to the Arbiter of the original OEP, or the
+`Architecture Group`_ if that Arbiter is no longer available. However, as a
 general guideline, the following updates would not require a replacement OEP.
 
 * Formatting changes.
@@ -472,6 +492,13 @@ alongside image files, to make it easy for others to update the OEP in the futur
 
 Change History
 ==============
+
+2022-01-13
+----------
+
+* Codifying that choosing an Arbiter, in practice, is done by the OEP Author(s)
+* Remove authority for assiting with arbitration and the overall process from
+  the edX internal architecture team to the Open edX community architecture group
 
 2020-10-01
 ----------


### PR DESCRIPTION
In the original doc, the process for getting an Arbitrator is to have one assigned by an internal edX team (I believe, at least - the wiki page linked to in the OEP is not publicly available). Moving forward, no one community member should have the ultimate authority in community decision making, not even tCRIL; I don't want tCRIL to just step in and take edX's place. Instead, I'd much rather a solution that allowed the whole community to participate in decision making, and this PR proposes a way for that to happen.

Additionally, I think it's reasonable to codify the fact that many of us are organically finding Arbiters due to us having domain expertise and knowing who in the community is out there working on the same or similar problems and would be good to arbitrate. Therefore I've written that part in, as a nod to existing practice. If we should not be doing this, I'll remove that point but I would like to add in some reasoning as to why that process should be followed.

docs: Clarify process of choosing Arbiters
* Codifying that choosing an Arbiter, in practice, is done by the OEP Author(s)
* Remove authority for assiting with arbitration and the overall process from
  the edX internal architecture team to the Open edX community architecture group
