### PR TITLE
fix: fix doc link and standardize title display

### DIFF
--- a/oeps/architectural-decisions/oep-0049-django-app-patterns.rst
+++ b/oeps/architectural-decisions/oep-0049-django-app-patterns.rst
@@ -1,13 +1,13 @@
 
 =============================
-OEP-0049: Django App Patterns
+OEP-49: Django App Patterns
 =============================
 
 .. list-table::
    :widths: 25 75
 
    * - OEP
-     - :doc:`OEP-0045 <oep-0049-django-app-patterns>`
+     - :doc:`OEP-0049 <oep-0049-django-app-patterns>`
    * - Title
      - Django App Patterns
    * - Last Modified


### PR DESCRIPTION
Fix the _name_ of the link to the doc file

<img width="390" alt="image" src="https://user-images.githubusercontent.com/1985317/155799203-2fe58568-30a2-4d1e-a626-b039fe52058a.png">

Standardize the way the title is displayed to match other oeps

<img width="264" alt="image" src="https://user-images.githubusercontent.com/1985317/155799170-615aee67-c03c-48cc-a10a-20926ef44e68.png">
