### PR TITLE
docs: fix OEP-56 changelog formatting

### DIFF
--- a/oeps/processes/oep-0056-proc-architectural-advisory-process.rst
+++ b/oeps/processes/oep-0056-proc-architectural-advisory-process.rst
@@ -210,6 +210,7 @@ Change History
 ==============
 
 2022-03-28
+----------
 
 * Folded "Appendix A" back into the document, as per feedback.  It's an important part of the flow of the OEP, and extracting it in an appendix made the document less clear overall.
 * Renamed "Decision Maker's Checklist" to "Decision Impact checklist" to be clearer around the role it plays in the process.  A separate "decision maker's checklist" may exist to help walk people through the overall AAP.


### PR DESCRIPTION
Was missing a heading on the latest date in the changelog.