### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/oeps/architectural-decisions/oep-0014-proc-archive-repos.rst
+++ b/oeps/architectural-decisions/oep-0014-proc-archive-repos.rst
@@ -68,7 +68,7 @@ First, if the repository is public, and a part of Open edX releases, follow thes
 4. Once the transfer has occurred, create a fork of the transferred repository into the `openedx organization`_ and follow the `Archive Steps`_ below for the forked repo.
 
 .. _Open edX Deprecation Announcements: https://discuss.openedx.org/c/announcements/deprecation
-.. _Open edX slack: http://openedx-slack-invite.herokuapp.com/
+.. _Open edX slack: http://openedx.org/slack
 .. _GitHub Request on the tCRIL board: https://github.com/openedx/tcril-engineering/issues/new/choose
 
 

--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -158,7 +158,7 @@ Group Discourse category`_ or the ``#architecture`` channel in the `Open edX
 Slack`_.
 
 .. _Architecture Group Discourse category: https://discuss.openedx.org/c/development/architecture/12
-.. _Open edX Slack: http://openedx-slack-invite.herokuapp.com/
+.. _Open edX Slack: http://openedx.org/slack
 
 *Note: If an architecture or similar working group is created, those details
 should be added here. Currently, the phrase "Architecture Group" refers to the

--- a/oeps/processes/oep-0021-proc-deprecation.rst
+++ b/oeps/processes/oep-0021-proc-deprecation.rst
@@ -312,7 +312,7 @@ Post the following in the #open-edx-proposals and #general `Open edX slack`_ cha
     deadline for comments before acceptance is <*Target Accepted Date*>.
     Once the ticket is accepted, removal can happen at any time.
 
-.. _`Open edX slack`: http://openedx-slack-invite.herokuapp.com/
+.. _`Open edX slack`: http://openedx.org/slack
 
 Monitor Feedback
 ~~~~~~~~~~~~~~~~

--- a/oeps/processes/oep-0054-core-contributors.rst
+++ b/oeps/processes/oep-0054-core-contributors.rst
@@ -275,7 +275,7 @@ forums, reading through to understand what's going on and jumping in to ask
 questions.  The ``#core-contributors`` room in `Open edX Slack
 <https://openedx.slack.com/>`_ can help guide people towards others working in
 their area(s) of interest. For those joining Slack for the first time, `here's
-an invite <http://openedx-slack-invite.herokuapp.com/>`_.
+an invite <http://openedx.org/slack>`_.
 
 Existing community members who have a record of contributing to the Open edX
 project should feel free to reach out to `current CCs


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.