### PR TITLE
docs: update OEP-21 with note on new usages of depr features

### DIFF
--- a/oeps/processes/oep-0021-proc-deprecation.rst
+++ b/oeps/processes/oep-0021-proc-deprecation.rst
@@ -342,6 +342,12 @@ update the state of the **DEPR** ticket to *Accepted*.
 For larger changes, it may be important to mention the upcoming deprecation
 in the release notes of the next named release.
 
+.. note::
+
+    If there's a new use of a feature once its deprecation ticket is accepted,
+    then the contributor must provide an ADR justifying its usage. This is because
+    using the deprecated feature obviously adds new technical debt to the system.
+
 Deprecated
 ----------
 


### PR DESCRIPTION
### Description
This PR adds a side note to the deprecation status accepted, so it suggests adding an explanation ADR when contributions use the deprecated feature. 

### Context
See thread https://openedx.slack.com/archives/CGB0S3L12/p1655937179658019
