### PR TITLE
docs: Small tweaks to ADR template

### DIFF
--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -160,7 +160,7 @@ A suggested ADR template:
 .. code-block:: rst
 
   0. Title For ADR
-  ##################
+  ################
   .. The title should be a short noun phrase. For example, "1. Django IDA" or "9. LDAP for Multitenant Integration"; filename should be lowercase with punctuation removed and spaces replaced by dash
 
   Status

--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -485,4 +485,4 @@ Change History
 2022-08-31
 ----------
 
-* Tweaks to ADR template
+* `Tweaks to ADR template <https://github.com/openedx/open-edx-proposals/pull/375>`_

--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -471,6 +471,11 @@ Next Steps
 Change History
 ==============
 
+2022-09-22
+----------
+
+* `Tweaks to ADR template <https://github.com/openedx/open-edx-proposals/pull/375>`_
+
 2022-06-22
 ----------
 
@@ -481,8 +486,3 @@ Change History
 
 * Add ADR template, add Change History section
 * `Pull request #340 <https://github.com/openedx/open-edx-proposals/pull/340>`_
-
-2022-08-31
-----------
-
-* `Tweaks to ADR template <https://github.com/openedx/open-edx-proposals/pull/375>`_

--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -159,9 +159,9 @@ A suggested ADR template:
 
 .. code-block:: rst
 
-  0000 Title For ADR
+  0. Title For ADR
   ##################
-  .. The title should be a short noun phrase. For example, "0001 Django IDA" or "0009 LDAP for Multitenant Integration"; filename should be lowercase with punctuation removed and spaces replaced by dash
+  .. The title should be a short noun phrase. For example, "1. Django IDA" or "9. LDAP for Multitenant Integration"; filename should be lowercase with punctuation removed and spaces replaced by dash
 
   Status
   ******
@@ -190,7 +190,7 @@ A suggested ADR template:
   .. This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
 
   Rejected Alternatives
-  ******************
+  *********************
 
   .. This section lists alternate options considered, described briefly, with pros and cons.
 
@@ -481,3 +481,8 @@ Change History
 
 * Add ADR template, add Change History section
 * `Pull request #340 <https://github.com/openedx/open-edx-proposals/pull/340>`_
+
+2022-08-31
+----------
+
+* Tweaks to ADR template


### PR DESCRIPTION
- Fix heading
- Use `1.` title instead of `0001`, since I think the former is more common (and readable)