### PR TITLE
refactor: no need for double headings, or empty index pages

### DIFF
--- a/oeps/index.rst
+++ b/oeps/index.rst
@@ -32,7 +32,6 @@ OEPs that relate to processes we want to put in place for the Open edX community
 .. toctree::
    :maxdepth: 1
    :glob:
-   :caption: Processes
 
    processes/oep-*
 
@@ -46,7 +45,6 @@ you have a good reason not to.
 .. toctree::
    :maxdepth: 1
    :glob:
-   :caption: Best Practices
 
    best-practices/oep-*
 
@@ -60,14 +58,5 @@ is no clear code repository where they should reside.
 .. toctree::
    :maxdepth: 1
    :glob:
-   :caption: Architectural Decisions
 
    architectural-decisions/oep-*
-
-
-Indices and tables
-##################
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
The published pages had duplicate "headings" on the home page:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/23789/192584525-8ed93cde-4c6d-438b-80db-3df8e777efac.png">

and also linked to three empty or non-existent index pages at the bottom.  This pull request cleans that up.