### PR TITLE
docs: Mark OEP-48 as Approved and OEP-23 as replaced

### DIFF
--- a/oeps/architectural-decisions/oep-0023-style-customization.rst
+++ b/oeps/architectural-decisions/oep-0023-style-customization.rst
@@ -12,7 +12,7 @@ OEP-23: Style Customization
 +-----------------+--------------------------------------------------------+
 | Arbiter         | Bill Filler <bfiller@edx.org>                          |
 +-----------------+--------------------------------------------------------+
-| Status          | Provisional                                            |
+| Status          | Replaced                                               |
 +-----------------+--------------------------------------------------------+
 | Type            | Architecture                                           |
 +-----------------+--------------------------------------------------------+
@@ -206,3 +206,8 @@ References
 
 8. edx-bootstrap edx theme
       https://github.com/openedx/edx-bootstrap/tree/v1.0.3/sass
+
+Change History
+**************
+
+2022-10-27: Marked this OEP as Replaced since OEP-48 serves as a continuation of this work and has now reached Accepted status.

--- a/oeps/architectural-decisions/oep-0048-brand-customization.rst
+++ b/oeps/architectural-decisions/oep-0048-brand-customization.rst
@@ -15,7 +15,7 @@ OEP-48: Brand Customization
    * - Arbiter
      - Kshitij Sobti <kshitij@opencraft.com>
    * - Status
-     - Approved
+     - Accepted
    * - Type
      - Architecture
    * - Created

--- a/oeps/architectural-decisions/oep-0048-brand-customization.rst
+++ b/oeps/architectural-decisions/oep-0048-brand-customization.rst
@@ -15,7 +15,7 @@ OEP-48: Brand Customization
    * - Arbiter
      - Kshitij Sobti <kshitij@opencraft.com>
    * - Status
-     - Provisional
+     - Approved
    * - Type
      - Architecture
    * - Created

--- a/oeps/architectural-decisions/oep-0048-brand-customization.rst
+++ b/oeps/architectural-decisions/oep-0048-brand-customization.rst
@@ -84,3 +84,8 @@ References
 **********
 
 See `npm cli documentation <https://docs.npmjs.com/cli-commands/install.html>`_ for further information about npm aliases.
+
+Change History
+**************
+
+2022-10-27: Marked this OEP as Accepted since the recommendations are already widely in use across the platform.


### PR DESCRIPTION
OEP-48 deals with customising branding for MFEs usin an npm package override.
This mechanism for branding is now supported across all MFEs, and is also
supported by both the configuration repo, and Tutor. As such this PR updates its
status from Provisional to Accepted.
