### PR TITLE
docs: update oep 52 (event bus architecture)

### DIFF
--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -17,13 +17,13 @@ OEP-52: Event Bus Architecture
    * - Arbiter
      - Tobias Macey <tmacey@mit.edu>
    * - Status
-     - Provisional
+     - Accepted
    * - Type
      - Architecture
    * - Created
      - 2021-08-16
    * - Review Period
-     - 2022-06-09 - 2022-06-30
+     - 2022-11-09 - 2022-06-30
 
 Overview
 ********
@@ -54,9 +54,8 @@ The already accepted :doc:`oep-0041-arch-async-server-event-messaging` details t
 * Flexibly integrate with event producers.
 * Simplify integration to external systems.
 
-However, this earlier OEP explicitly leaves out of scope the specific transport and libraries used for this messaging. At this time, the Open edX platform still lacks a reliable way to send events to multiple consumers across services, following the publish-subscribe (pub/sub) messaging pattern.
+However, this earlier OEP explicitly leaves out of scope the specific transport and libraries used for this messaging. At the time, the Open edX platform lacked a reliable way to send events to multiple consumers across services, following the `publish-subscribe messaging pattern`_ (pub/sub).
 
-In other words, we have documented what we wish to do and why, but we do not yet fully have the capability to do it. We are missing a reliable event messaging infrastructure with `publish-subscribe messaging pattern`_ (pub/sub) capabilities.
 
 .. _Architecture Manifesto: https://openedx.atlassian.net/wiki/spaces/AC/pages/1074397222/Architecture+Manifesto+WIP
 .. _publish-subscribe messaging pattern: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
@@ -69,8 +68,6 @@ Decision
 * For the purpose of this OEP, the focus of the event bus is to provide `publish-subscribe messaging pattern`_ (pub/sub) and event-driven capabilities.
 
 * An abstraction layer will be provided to enable the choice of multiple technologies for implementing an Open edX event bus.
-
-.. note:: All referenced ADRs are Provisional at this time, until we are able to confirm decisions through a production-validated implementation. **TODO:** Update references to edx.org ADRs as they move around.
 
 * An initial event bus implementation is being implemented using Kafka.
 
@@ -102,6 +99,11 @@ Consequences
 
 Change History
 **************
+
+2022-11-29
+==========
+
+* Removed disclaimer about provisional ADRs (all have since been accepted)
 
 2022-07-11
 ==========

--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -105,7 +105,7 @@ Change History
 2022-11-29
 ==========
 
-* Removed disclaimer about provisional ADRs (all have since been accepted)
+* Removed disclaimer about provisional ADRs (all have since been accepted) and added follow-up work in References
 
 2022-07-11
 ==========

--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -79,8 +79,8 @@ Decision
 
 * Event bus events will further extend the Hooks Extension Framework events, and use an Avro schema to serialize the existing hooks signals.
 
-  * See `ADR on External event bus and Django Signal events`_ to learn more about how the ``OpenEdxPublicSignal`` internal event will be used to send the same internal signal-based events across services, and then fire the signal-based events again within consuming services.
-  * See `ADR on External Event Schema Format`_ and `ADR on Event Schema Serialization and Evolution`_ to learn about how the Avro Schema format will be used for serializing external events published to Kafka, and consumed from Kafka. Additionally, learn about tooling to automatically handle the translation from ``OpenEdxPublicSignal`` internal events to Avro Schema formatted events, and back again. Also learn how this explicit schema format can aid in schema evolution.
+  * See (provisional) `ADR on External event bus and Django Signal events`_ to learn more about how the ``OpenEdxPublicSignal`` internal event will be used to send the same internal signal-based events across services, and then fire the signal-based events again within consuming services.
+  * See `ADR on External Event Schema Format`_ and (provisional) `ADR on Event Schema Serialization and Evolution`_ to learn about how the Avro Schema format will be used for serializing external events published to Kafka, and consumed from Kafka. Additionally, learn about tooling to automatically handle the translation from ``OpenEdxPublicSignal`` internal events to Avro Schema formatted events, and back again. Also learn how this explicit schema format can aid in schema evolution.
 
 .. _ADR on Kafka-Based Event Bus: https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0002-kafka-based-event-bus.rst
 .. _ADR on Kafka Managed Hosting: https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0004-kafka-managed-hosting.rst

--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -17,13 +17,15 @@ OEP-52: Event Bus Architecture
    * - Arbiter
      - Tobias Macey <tmacey@mit.edu>
    * - Status
-     - Accepted
+     - Provisional
    * - Type
      - Architecture
    * - Created
      - 2021-08-16
    * - Review Period
      - 2022-11-09 - 2022-06-30
+   * - References
+     - Follow up work: `event bus project roadmap`_
 
 Overview
 ********


### PR DESCRIPTION
Update OEP-52 to better reflect the current state of the event bus project.