### PR TITLE
OEP-54 - Core Contributors - Define work scope

### DIFF
--- a/oeps/processes/oep-0054-core-contributors.rst
+++ b/oeps/processes/oep-0054-core-contributors.rst
@@ -114,6 +114,11 @@ organization's Core Contributors, however, we recognize that circumstances
 differ and a different commitment may be more appropriate. Before signing the
 agreement, please `Contact the Program Administrators`_ to discuss.
 
+The scope of the work or contributions considered as part of the Core 
+Contributors duties, and counted towards an organization's commitments, is
+defined at 
+`<https://openedx.atlassian.net/wiki/spaces/COMM/pages/3593502844/Core+Contributor+-+Work+Scope>`_
+
 Questions about the Program can be directed to the tCRIL administrator(s) via
 the ``#core-contributors`` Slack room in the `Open edX Slack
 <https://openedx.slack.com/>`_.


### PR DESCRIPTION
This update to OEP-54 adds a link to the reference definition of what is being considered "core contributor work", which will live in the wiki. 

The corresponding review can be found in the forum at https://discuss.openedx.org/t/final-review-core-contributors-work-scope/8821