### PR TITLE
Remove note about OER Enchancement Proposals

### DIFF
--- a/oeps/index.rst
+++ b/oeps/index.rst
@@ -14,13 +14,6 @@ choice. OEPs are not the only way for a change to be made to Open edX, however,
 the goal is to create a collection of OEP documents as a repository or knowledge
 archive of large and broadly relevant choices made for the platform.
 
-.. note::
-
-    This is the listing of all Open edX Proposals (OEPs). If you are looking for
-    OER Enhancement Proposals, please visit `oep.readthedocs.io`_.
-
-.. _oep.readthedocs.io: https://oep.readthedocs.io
-
 OEPs
 ****
 


### PR DESCRIPTION
On our OEP homepage there's a note about  which also have the acronym OEP. However, the page listed (oep.readthedocs.io) hasn't been updated since 2016. Thus I believe there is not an appetite for people looking for OER Enhancement Proposals, and it seems a little silly for us to provide a redirect. Googling OEP yields tons of different acronyms, most commonly is Open Enrollment Period for US Healthcare. Anyway. @feanil ?