### PR TITLE
build: Make develop work out of the box.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,8 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 .PHONY: develop
-develop:
-	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -p $(PORT) --ignore '.git/**' --open-browser
+develop: dev-requirements
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html --port $(PORT) --ignore '.git/**' --open-browser
 
 COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
 .PHONY: $(COMMON_CONSTRAINTS_TXT)


### PR DESCRIPTION
Update the develop target so that it builds the dev requirements and
correct the arguments for the port since the options have changed.
