### PR TITLE
fix: add punctuation in OEP-49

### DIFF
--- a/oeps/best-practices/oep-0049-django-app-patterns.rst
+++ b/oeps/best-practices/oep-0049-django-app-patterns.rst
@@ -62,7 +62,7 @@ Listed below are each of the files or folders your app should contain and what t
 README.rst
 ==========
 
-Each app should contain a README.rst to explain its use. See full details of what should go in the README.rst in OEP-0019_
+Each app should contain a README.rst to explain its use. See full details of what should go in the README.rst in OEP-0019_.
 
 .. _OEP-0019: https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html#readmes
 


### PR DESCRIPTION
This is just to try force a readthedocs build, but that sentence could use a period for consistency anyway.