### PR TITLE
fix: updating a broken link

### DIFF
--- a/oeps/best-practices/oep-0013.rst
+++ b/oeps/best-practices/oep-0013.rst
@@ -34,7 +34,7 @@ Abstract
 
 This document captures the conventions to be used for all Open edX web APIs.
 
-Update: moved to https://openedx.atlassian.net/wiki/display/OpenDev/edX+REST+API+Conventions.
+Update: moved to https://openedx.atlassian.net/wiki/spaces/AC/pages/18350757/edX+REST+API+Conventions.
 
 Motivation
 **********


### PR DESCRIPTION
Updating the link for the wiki area for the Rest Best Practices.