### PR TITLE
Fix examples of enumerations and attrs in OEP-49 App Patterns: data.py

### DIFF
--- a/oeps/best-practices/oep-0049-django-app-patterns.rst
+++ b/oeps/best-practices/oep-0049-django-app-patterns.rst
@@ -203,26 +203,17 @@ Example
 
   from enum import Enum
 
-  import attr
-
-  def ProgramStatus(Enum):
+  from attrs import field, frozen, validators
+  
+  class ProgramStatus(Enum):
       ACTIVE = "active"
       RETIRED = "retired"
 
-  @attr.attrs(frozen=True)
+  @frozen
   class ProgramData:
-      uuid: str = attr.attrib(
-          validator=[attr.validators.instance_of(str)]
-      )
-      title: str = attr.attrib(
-          validator=[attr.validators.instance_of(str)]
-      )
-      status: str = attr.attrib(
-          validator=[
-              attr.validators.instance_of(str),
-              attr.validators.in_(ProgramStatus)
-          ]
-      )
+      uuid: str = field(validator=validators.instance_of(str))
+      title: str = field(validator=validators.instance_of(str))
+      status: ProgramStatus = field(validator=validators.in_(ProgramStatus), converter=ProgramStatus)
 
 .. _rest_api:
 
@@ -289,6 +280,11 @@ At this time, there is no plan to enforce any of these guidelines. The vast majo
 
 Change History
 **************
+
+2023-04-26
+==========
+
+* In the section about data.py, fixed some broken examples of enum handling and converted to modern ``attrs`` syntax
 
 2023-04-20
 ==========


### PR DESCRIPTION
In [OEP-49](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0049-django-app-patterns.html#data-py), it gives this example of how to use [`attrs`](https://www.attrs.org/en/stable/) in data.py:

```python
from enum import Enum

import attr

def ProgramStatus(Enum):
    ACTIVE = "active"
    RETIRED = "retired"

@attr.attrs(frozen=True)
class ProgramData:
    uuid: str = attr.attrib(
        validator=[attr.validators.instance_of(str)]
    )
    title: str = attr.attrib(
        validator=[attr.validators.instance_of(str)]
    )
    status: str = attr.attrib(
        validator=[
            attr.validators.instance_of(str),
            attr.validators.in_(ProgramStatus)
        ]
    )
```

There are two problems with this:
1. It should not be using `def` but rather `class` to define the enum. As shown, the declaration is accepted but the enum won't work.
2. The `status` field of `ProgramData` will not actually accept any value, because enum members are not strings and strings are not enum numbers, so the validators conflict:

```python
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE)
...
TypeError: ("'status' must be <class 'str'> (got <ProgramStatus.ACTIVE: 'active'> that is a <enum 'ProgramStatus'>).", ...)
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE.value)
...
ValueError: ("'status' must be in <enum 'ProgramStatus'> (got 'active')", ...)
```

I believe that a better, working, and modern example would be this, which is what I've put in the PR:

```python
from enum import Enum

from attrs import field, frozen, validators

class ProgramStatus(Enum):
    ACTIVE = "active"
    RETIRED = "retired"

@frozen
class ProgramData:
    uuid: str = field(validator=validators.instance_of(str))
    title: str = field(validator=validators.instance_of(str))
    status: ProgramStatus = field(validator=validators.in_(ProgramStatus), converter=ProgramStatus)
```

This works, is more concise, uses standard python enums, and also uses [the more modern `attrs` syntax](https://www.attrs.org/en/stable/names.html) which they recommend for all new code.

Putting `converter=ProgramStatus` allows this new type to accept three different forms of the enum value, but coerces them all to a standard form for consistency:

```python
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE)
ProgramData(uuid='', title='', status=<ProgramStatus.ACTIVE: 'active'>)
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE.value)
ProgramData(uuid='', title='', status=<ProgramStatus.ACTIVE: 'active'>)
>>> ProgramData(uuid="", title="", status="active")
ProgramData(uuid='', title='', status=<ProgramStatus.ACTIVE: 'active'>)

>>> ProgramData(uuid="", title="", status="invalid")
ValueError: 'invalid' is not a valid ProgramStatus
```

## Alternative 1

Alternately, it could be suggested to not use `converter=ProgramStatus`, though that can be potentially confusing as it's very strict about what it accepts:

```python
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE)
ProgramData(uuid='', title='', status=<ProgramStatus.ACTIVE: 'active'>)
>>> ProgramData(uuid="", title="", status=ProgramStatus.ACTIVE.value)
...
ValueError: ("'status' must be in <enum 'ProgramStatus'> (got 'active')", ...)
>>> ProgramData(uuid="", title="", status="active")
...
ValueError: ("'status' must be in <enum 'ProgramStatus'> (got 'active')", ...)
```

## Alternative 2

It could be nice to use Django's [`models.TextChoices`](https://docs.djangoproject.com/en/4.0/ref/models/fields/#field-choices-enum-types) etc. instead of a stdlib python enum, because they support internationalized names and can be used directly with Django model `choices`. However, this goes against the recommendation in OEP-49 which says "This file should not import anything other than stdlib modules". (Though it clearly recommends `attrs` for the same file which is not a stdlib module.)

```python
from attrs import field, frozen, validators
from django.db import models
from django.utils.translation import gettext_lazy as _


class ProgramStatus(models.TextChoices):
    ACTIVE = "active", _("Active")
    RETIRED = "retired", _("Retired")

@frozen
class ProgramData:
    uuid: str = field(validator=validators.instance_of(str))
    title: str = field(validator=validators.instance_of(str))
    status: ProgramStatus = field(validator=validators.in_(ProgramStatus), converter=ProgramStatus)
```

When using the Django enums, `converter=ProgramStatus` is necessary as there is otherwise some auto-conversion going on which makes it accept an enum member value or plain string value, resulting in equivalent but inconsistently typed values being stored in the data structure. So that potential footgun could be a reason to prefer regular enums in situations where localization is not useful.

## Alternative 3

A nice option could be python stdlib's [`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum) but it's only in Python 3.11, so we can't use it yet. It avoids most of the data type complexities that I've found (see below) though it doesn't support internationalizing the labels like Django enums do.