### PR TITLE
docs: adr that outlines tools for enzyme migration

### DIFF
--- a/oeps/best-practices/oep-0011-bp-FED-technology.rst
+++ b/oeps/best-practices/oep-0011-bp-FED-technology.rst
@@ -271,8 +271,25 @@ Rejected Alternatives
    * It does not and will not support React 18.
    * The community is unwilling to create an adapter for React 18.
 
+Related Decisions
+*****************
+
+The following related decisions modify or enhance this OEP, but have not yet been fully incorporated as updates to this OEP:
+
+.. toctree::
+   :caption: OEP-11 Decisions
+   :maxdepth: 1
+   :glob:
+
+   oep-0011/decisions/*
+
 Change History
 **************
+
+2023-06-23
+==========
+* Add related decisions section and ADR for enzyme deprecation process
+* `Pull request #501 <https://github.com/openedx/open-edx-proposals/pull/501>`_
 
 2023-05-23
 ==========

--- a/oeps/best-practices/oep-0011/decisions/0001-enzyme-deprecation.rst
+++ b/oeps/best-practices/oep-0011/decisions/0001-enzyme-deprecation.rst
@@ -1,0 +1,53 @@
+Enzyme Deprecation
+##################
+
+Status
+******
+
+Proposed
+
+Context
+*******
+
+We recently `updated OEP-11 to deprecate enzyme`_, due to the fact that enzyme will not support React 18. We also started
+the `deprecation process for enzyme`_. Now the question is how to practically migrate away from enzyme.
+
+We have updated the OEP to say that we are now (generally) using react-testing-library for our tests, but there is a caveat,
+which this ADR addresses.
+
+Migrating a test file from enzyme to react-testing-library is not a simple find and replace. The two libraries have different
+APIs and philosophies. So it means completely rewriting the test file. This is very costly in terms of work,
+will take a lot of time and thus block our upgrade to React 18, and is also risky, since it is hard to estimate how long
+we will need.
+
+To put this into perspective, there is a `blog post from sentry on their estimated timeline for migration`_.
+They estimate updating 8 test files a week and needing more than a year for 520 files. We have much more than that.
+
+A solution for this is our `react-unit-test-utils`_, a wrapper library we created around react-test-renderer that has a
+similar, but reduced API to enzyme. It makes it very simple to replace enzyme with this and saves most of the effort.
+
+Decision
+********
+
+All existing enzyme tests for repos that are planning to adopt React 18 should be migrated over to `react-unit-test-utils`_.
+
+The recommended tool for writing new tests is still `react-testing-library`_.
+
+Consequence
+***********
+
+This will allow us to migrate to React 18 without having to rewrite all our tests, and significantly reduce cost, time, and risk.
+
+Rejected Alternatives
+*********************
+
+- Migrate directly to `react-testing-library`_. This is not considered feasible due to effort and risk.
+- Create a new wrapper library around `react-testing-library`_ that has a similar API to enzyme. This has been
+tried and has not worked.
+
+
+.. _updated OEP-11 to deprecate enzyme: https://github.com/openedx/open-edx-proposals/pull/487
+.. _deprecation process for enzyme: https://github.com/openedx/public-engineering/issues/195
+.. _blog post from sentry on their estimated timeline for migration: https://blog.sentry.io/sentrys-frontend-tests-migrating-from-enzyme-to-react-testing-library/#estimation-migration-time
+.. _react-testing-library: https://testing-library.com/docs/react-testing-library/intro/
+.. _react-unit-test-utils: https://github.com/muselesscreator/react-unit-test-utils

--- a/oeps/best-practices/oep-0011/decisions/0001-enzyme-deprecation.rst
+++ b/oeps/best-practices/oep-0011/decisions/0001-enzyme-deprecation.rst
@@ -43,8 +43,7 @@ Rejected Alternatives
 
 - Migrate directly to `react-testing-library`_. This is not considered feasible due to effort and risk.
 - Create a new wrapper library around `react-testing-library`_ that has a similar API to enzyme. This has been
-tried and has not worked.
-
+  tried and has not worked.
 
 .. _updated OEP-11 to deprecate enzyme: https://github.com/openedx/open-edx-proposals/pull/487
 .. _deprecation process for enzyme: https://github.com/openedx/public-engineering/issues/195


### PR DESCRIPTION
TLDR;

We propose that existing enzyme tests in openedx migrate over to https://github.com/openedx/react-unit-test-utils.
For new tests, we still recommend react-testing-library.

The reason is that it takes much too long and is too risky to migrate directly to react-testing-library, because we would have to rewrite every test file.