### PR TITLE
Add README for OEP-57 diagram sources

### DIFF
--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -96,7 +96,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -96,7 +96,7 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**/README.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/oeps/processes/oep-0057/README.rst
+++ b/oeps/processes/oep-0057/README.rst
@@ -1,0 +1,10 @@
+OEP-0057 File README
+####################
+
+The source for both diagrams live in LucidChart.
+
+They can be found `at this LucidChart URL <https://lucid.app/lucidchart/45a5cd3f-60c8-4d40-8bb4-3aee2eae66d2/view?page=MHqY~t-BcHS8#>`_
+and should be visible by everyone. If you need to edit a chart, either copy the chart
+into your own Lucid account or get in touch with the original authors, if possible
+(Kyle, Sarina, Jenna - listed on the OEP) for access.
+


### PR DESCRIPTION
We authored these in LucidChart and while that text is contained within the OEP, it feels even better to put that info directly where someone looking at the diagram source would want to know about it.