### PR TITLE
Add a Needs Revision status for OEPs

### DIFF
--- a/oeps/architectural-decisions/oep-0045-arch-ops-and-config.rst
+++ b/oeps/architectural-decisions/oep-0045-arch-ops-and-config.rst
@@ -9,13 +9,15 @@ OEP-45: Configuring and Operating Open edX
    * - Title
      - Configuring and Operating Open edX
    * - Last Modified
-     - 2020-04-06
+     - 2024-05-17
    * - Authors
      - Bill DeRusha <bill@edx.org>
    * - Arbiter
      - Felipe Montoya <felipe.montoya@edunext.co>
    * - Status
-     - Accepted
+     - Needs Revision
+   * - Revision Ticket
+     - https://github.com/openedx/open-edx-proposals/issues/587
    * - Type
      - Architecture
    * - Created
@@ -210,3 +212,10 @@ The following related decisions modify or enhance this OEP, but have not yet bee
 
    oep-0045/decisions/*
 
+Change History
+**************
+
+2024-05-16
+==========
+* Change status to "Needs Revision"
+* `Pull request #586 <https://github.com/openedx/open-edx-proposals/pull/586>`_

--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -8,11 +8,11 @@ OEP-1: OEP Purpose and Guidelines
 +---------------+--------------------------------------------------------------+
 | Last-Modified | 2022-06-22                                                   |
 +---------------+--------------------------------------------------------------+
-| Authors       | Calen Pennington <cale@edx.org>,                             |
-|               | Joel Barciauskas <joel@edx.org>,                             |
-|               | Nimisha Asthagiri <nimisha@edx.org>,                         |
-|               | Feanil Patel <feanil@axim.org>,                              |
-|               | Sarina Canelake <sarina@axim.org>                            |
+| Authors       | - Calen Pennington <cale@edx.org>                            |
+|               | - Joel Barciauskas <joel@edx.org>                            |
+|               | - Nimisha Asthagiri <nimisha@edx.org>                        |
+|               | - Feanil Patel <feanil@axim.org>                             |
+|               | - Sarina Canelake <sarina@axim.org>                          |
 +---------------+--------------------------------------------------------------+
 | Arbiter       | - Eddie Fagin <efagin@edx.org>,                              |
 |               | - Calen Pennington <cale@edx.org>                            |

--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -245,7 +245,7 @@ OEP Status
         "Under Review" -> { "Deferred" "Provisional" } [dir=both]
         "Under Review" ->  { "Accepted" "Rejected" "Withdrawn" }
         "Accepted" -> "Final"
-        "Final" -> { "Replaced" "Obsolete" } [style=dashed] [style=dashed]
+        "Final" -> { "Replaced" "Obsolete" "Needs Revision" } [style=dashed] [style=dashed]
     }
 
 Draft
@@ -308,6 +308,19 @@ guidelines. In this case the OEP's status should be changed to "Obsolete" and
 the OEP should be updated with an explanation as to why the OEP is no
 longer relevant.
 
+Needs Revision
+--------------
+
+Over time, some OEPs may stay relevant - for example, they may have many
+sections or core ideas that are still relevant to the project - while containing
+many details that have become stale over time. When we are in agreement that the
+OEP needs updating, we use this status to indicate to those browsing the OEPs
+that this particular one requires some renewed attention.
+
+When changing status to "Needs Revision", a row titled "Revision Ticket" should
+be added to the preamble (directly under the status field) that directs to the
+GitHub issue or draft pull request in the ``open-edx-proposals`` repository that
+describes what about the OEP that needs revisioning.
 
 Status changes
 --------------
@@ -551,6 +564,11 @@ at the top of the list.
 
 Change History
 **************
+
+2024-05-16
+==========
+* Add a "Needs Revision" status
+* `Pull request #586 <https://github.com/openedx/open-edx-proposals/pull/586>`_
 
 2022-10-05
 ==========

--- a/oeps/processes/oep-0001.rst
+++ b/oeps/processes/oep-0001.rst
@@ -242,6 +242,7 @@ OEP Status
         [fontname=Arial]
 
         "Draft" -> { "Under Review" "Deferred" }
+        "Needs Revision" -> "Under Review"
         "Under Review" -> { "Deferred" "Provisional" } [dir=both]
         "Under Review" ->  { "Accepted" "Rejected" "Withdrawn" }
         "Accepted" -> "Final"


### PR DESCRIPTION
Over time, some OEPs may stay relevant - for example, they may have many
sections or core ideas that are still relevant to the project - while containing
many details that have become stale over time. When we are in agreement that the
OEP needs updating, we use this status to indicate to those browsing the OEPs
that this particular one requires some renewed attention.

When changing status to "Needs Revision", a row titled "Revision Ticket" should
be added to the preamble (directly under the status field) that directs to the
GitHub issue or draft pull request in the ``open-edx-proposals`` repository that
describes what about the OEP that needs revisioning.

An example is added with OEP-45. OEP-45 is directionally correct and we shouldn't mark it as _obsolete_ - it contains many great ideas. However it very much needs revision. We've captured the revision needs in https://github.com/openedx/open-edx-proposals/issues/587 and linked that issue to the OEP.

It is not always feasible that we find something wrong in an OEP and have the time right then and there to update the OEP. This status is a nod to that reality and a signpole to community members that they should tread carefully.