### PR TITLE
Clarify how devDependencies should be used for NPM packages (OEP-67: Standard Tools and Technologies)

### DIFF
--- a/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
+++ b/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
@@ -340,6 +340,8 @@ Change History
 2024-07-25
 ==========
 
+* Added "Development dependencies should be separated into devDependencies"
+* `Pull request #615 <https://github.com/openedx/open-edx-proposals/pull/615>`_
 * Changed guidance on React state/data loading to recommend React Query instead of Redux
 * Updated JavaScript/TypeScript guidance
 * `Pull request #616 <https://github.com/openedx/open-edx-proposals/pull/616>`_

--- a/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
+++ b/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
@@ -254,6 +254,16 @@ Frontend Technology Selection
    don't unintentionally increase the size of our JavaScript bundles, we utilize BundleWatch
    for automated bundle size monitoring.
 
+#. **Development dependencies should be separated into devDependencies**
+
+   **Rationale**: To keep installation and deployment of our MFEs as fast as
+   possible, the "dependencies" field in ``package.json`` should reference only
+   the packages needed to build the bundle of the MFE (this includes webpack via
+   frontend-build, as well as any dependencies used in the actual MFE/React
+   code). Any dependencies used only for testing, linting, formatting, or other
+   development tasks should be put into "devDependencies" (e.g. Jest, eslint,
+   TypeScript, ``@types/`` packages, etc.).
+
 Backend Technology Selection
 ============================
 


### PR DESCRIPTION
Per a discussion with @regisb about how we can speed up MFE build times in Tutor, I want to clarify how `dependencies` and `devDependencies` should be used. The goal is that tutor can install MFE dependencies using `npm ci --production` which would do a fast install that excludes `devDependencies`. This will be a significant speedup in the case where we can exclude things like Jest (which is a very large and bloated package[^1]) that aren't needed just to build and deploy the MFE.


Note: this is very much _not_ the case now:
* `frontend-build` [includes](https://github.com/openedx/frontend-build/blob/ae8ce98d5252d9ddd4e730d6b21ca40257453bef/package.json) Jest, eslint, TypeScript, react-dev-utils, and more in `dependencies`, and puts `@babel/preset-typescript` which I think is required for build in `devDependencies`
* `course-authoring` MFE [puts](https://github.com/openedx/frontend-app-course-authoring/blob/649863d094056e659b30bb84107649843eeef80b/package.json) `frontend-build` and `axios` as `devDependencies`
* The learning MFE [puts](https://github.com/openedx/frontend-app-learning/blob/7efe8f5cc3778a8ca6aba2b525963f19916d6722/package.json) `frontend-build` as a devDependency
* The learner-dashboard MFE [puts](https://github.com/openedx/frontend-app-learner-dashboard/blob/5b6c4004c7a45a30dbe25db1b1285276f598c271/package.json) `jest`, `@testing-library/user-event`, and `redux-devtools-extension` as `dependencies` while putting `@openedx/frontend-build` as a devDependency

[^1]: `npx howfat jest` says `487 deps, 49.6mb`