### PR TITLE
build: tag correct owner for review on uprgade PRs

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,8 +13,8 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "arbi-bom"
-       email_address: arbi-bom@edx.org  
+       user_reviewers: "sarina"
+       email_address: sarina@axim.org  
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, Arbi-BOM is being tagged on upgrade PRs but this repo is owned by Sarina as per the catalog-info.yml file, so updating github actions to tag Sarina instead.