### PR TITLE
docs: Fix status of OEP-63

### DIFF
--- a/oeps/processes/oep-0063-proc-toc-resolution-request.rst
+++ b/oeps/processes/oep-0063-proc-toc-resolution-request.rst
@@ -17,7 +17,7 @@ OEP-63: TOC Resolution Request
    * - Arbiter
      - Ed Zarecor
    * - Status
-     - Draft
+     - Accepted
    * - Type
      - Process
    * - Created


### PR DESCRIPTION
OEP-63 was accepted and merged in https://github.com/openedx/open-edx-proposals/pull/484 but the status of the OEP hasn't been updated.