### PR TITLE
docs: [FC-0074] add note about decisions documented in each hooks repositories

### DIFF
--- a/oeps/architectural-decisions/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/architectural-decisions/oep-0041-arch-async-server-event-messaging.rst
@@ -475,9 +475,15 @@ Having a clearly defined set of events would allow for simpler third party
 integration in areas like student learner event processing and course catalog
 management.
 
+------------
+
+.. note:: All future decisions related to :doc:`Open edX Events <openedx-events:index>` that adhere to these guidelines for asynchronous event messaging will now be documented and made publicly available through the Architectural Decision Records (ADRs) in :doc:`Open edX Events ADRs <openedx-events:decisions/index>`. This includes decisions regarding the Event Bus, schema format, serialization, evolution, and design practices for event-driven architecture.
+
 **************
 Change History
 **************
+
+2024-01-14: Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
 
 2022-01-09: Clarified that time field could be based on updated_at time when appropriate.
 

--- a/oeps/architectural-decisions/oep-0041-arch-async-server-event-messaging.rst
+++ b/oeps/architectural-decisions/oep-0041-arch-async-server-event-messaging.rst
@@ -483,7 +483,7 @@ management.
 Change History
 **************
 
-2024-01-14: Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
+2024-01-14: Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the `openedx-events <https://github.com/openedx/openedx-events>`_ repository.
 
 2022-01-09: Clarified that time field could be based on updated_at time when appropriate.
 

--- a/oeps/architectural-decisions/oep-0050-hooks-extension-framework.rst
+++ b/oeps/architectural-decisions/oep-0050-hooks-extension-framework.rst
@@ -263,8 +263,13 @@ The current documentation for the Hooks Extension Framework can be found at `Ope
 
 .. _Open edX Guides Hooks: https://github.com/openedx/edx-platform/tree/master/docs/guides/hooks
 
+.. note:: All decisions related to Open edX Events and Filters will now be documented and made publicly available through their respective Architectural Decision Records (ADRs). For more information, see the :doc:`Open edX Events ADRs <openedx-events:decisions/index>` and :doc:`Open edX Filters ADRs <openedx-filters:decisions/index>`.
+
 Change History
 **************
+
+14 January 2025 - Maria Grimaldi
+Added note about decisions related to Open edX Events and Filters being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
 
 20 July 2022 - Maria Grimaldi
 Update OEP-50 with latest documentation.

--- a/oeps/architectural-decisions/oep-0050-hooks-extension-framework.rst
+++ b/oeps/architectural-decisions/oep-0050-hooks-extension-framework.rst
@@ -269,7 +269,7 @@ Change History
 **************
 
 14 January 2025 - Maria Grimaldi
-Added note about decisions related to Open edX Events and Filters being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
+Added note about decisions related to Open edX Events and Filters being documented and made publicly available through the Architectural Decision Records (ADRs) in the `openedx-events <https://github.com/openedx/openedx-events>`_ and `openedx-filters <https://github.com/openedx/openedx-events>`_ repositories.
 
 20 July 2022 - Maria Grimaldi
 Update OEP-50 with latest documentation.

--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -96,6 +96,8 @@ Decision
 .. _ADR on External Event Schema Format: https://openedx-events.readthedocs.io/en/latest/decisions/0005-external-event-schema-format.html
 .. _ADR on Event Schema Serialization and Evolution: https://openedx-events.readthedocs.io/en/latest/decisions/0006-event-schema-serialization-and-evolution.html
 
+.. note:: All decisions related to Open edX Events where the event bus key components are implemented will now be documented and made publicly available through the Architectural Decision Records (ADRs) in the repository. For more details, refer to the :doc:`Open edX Events ADRs <openedx-events:decisions/index>`.
+
 Consequences
 ************
 
@@ -107,6 +109,11 @@ Consequences
 
 Change History
 **************
+
+2025-01-14
+==========
+
+* Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
 
 2024-07-09
 ==========

--- a/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
+++ b/oeps/architectural-decisions/oep-0052-arch-event-bus-architecture.rst
@@ -96,7 +96,7 @@ Decision
 .. _ADR on External Event Schema Format: https://openedx-events.readthedocs.io/en/latest/decisions/0005-external-event-schema-format.html
 .. _ADR on Event Schema Serialization and Evolution: https://openedx-events.readthedocs.io/en/latest/decisions/0006-event-schema-serialization-and-evolution.html
 
-.. note:: All decisions related to Open edX Events where the event bus key components are implemented will now be documented and made publicly available through the Architectural Decision Records (ADRs) in the repository. For more details, refer to the :doc:`Open edX Events ADRs <openedx-events:decisions/index>`.
+.. note:: All decisions related to Open edX Events where the event bus key components are implemented will now be documented and made publicly available through the Architectural Decision Records (ADRs) in the `openedx-events <https://github.com/openedx/openedx-events>`_ repository. For more details, refer to the :doc:`Open edX Events ADRs <openedx-events:decisions/index>`.
 
 Consequences
 ************
@@ -113,7 +113,7 @@ Change History
 2025-01-14
 ==========
 
-* Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the repository.
+* Added note about decisions related to Open edX Events being documented and made publicly available through the Architectural Decision Records (ADRs) in the `openedx-events <https://github.com/openedx/openedx-events>`_ repository.
 
 2024-07-09
 ==========

--- a/oeps/conf.py
+++ b/oeps/conf.py
@@ -360,6 +360,14 @@ intersphinx_mapping = {
         f"https://docs.openedx.org/{rtd_language}/{rtd_version}",
         None,
     ),
+    "openedx-events": (
+        f"https://docs.openedx.org/projects/openedx-events/{rtd_language}/latest",
+        None,
+    ),
+    "openedx-filters": (
+        f"https://docs.openedx.org/projects/openedx-filters/{rtd_language}/latest",
+        None,
+    ),
 }
 
 # -- Read the Docs Specific Configuration


### PR DESCRIPTION
### Description

This PR adds notes about Open edX Events and Filters to event-driven-related OEPs and the Hooks Extension Framework OEP, specifying where to find architectural decisions about the framework. This PR addresses: https://github.com/openedx/openedx-events/pull/438#pullrequestreview-2546953891