### PR TITLE
docs: Update edx.rtd.io links to their docs.openedx.org equivalents

### DIFF
--- a/oeps/architectural-decisions/oep-0026-arch-realtime-events.rst
+++ b/oeps/architectural-decisions/oep-0026-arch-realtime-events.rst
@@ -52,7 +52,7 @@ This OEP proposes an evolutionary change to Open edX's eventing system that will
 
 This document describes a design proposal for supporting standard real-time events in the Open edX system.
 
-.. _Events in the Tracking Logs: https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html
+.. _Events in the Tracking Logs: https://docs.openedx.org/en/latest/developers/references/internal_data_formats/index.html
 .. _xAPI: https://xapi.com/
 .. _Caliper: https://www.imsglobal.org/activity/caliper
 .. _human perception: https://www.pubnub.com/blog/how-fast-is-realtime-human-perception-and-technology/

--- a/oeps/architectural-decisions/oep-0031-arch-i18n.rst
+++ b/oeps/architectural-decisions/oep-0031-arch-i18n.rst
@@ -159,7 +159,7 @@ Cross-Site Scripting Vulnerability
 
 Because translated strings often contain placeholders that will be filled in at render time, possibly using user input, localization is a potential opening for cross-site scripting (XSS) attacks. The ``react-intl`` functions exposed by frontend-platform are XSS-safe.
 
-We explicitly don't export ``react-intl`` components that are not XSS safe, such as ``FormattedHTMLMessage``.  See `Don't Use FormattedHTMLMessage` <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss_in_react.html#don-t-use-formattedhtmlmessage>`_ for more information.
+We explicitly don't export ``react-intl`` components that are not XSS safe, such as ``FormattedHTMLMessage``.  See `Preventing XSS in React` <https://docs.openedx.org/en/latest/developers/references/developer_guide/preventing_xss/preventing_xss_in_react.html>`_ for more information.
 
 Mapping Server Codes To Messages
 --------------------------------
@@ -251,7 +251,7 @@ References
 
 #. Determining a language tag for a user: https://www.w3.org/International/articles/language-tags/
 
-#. XSS in ``react-intl``: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss_in_react.html#i18n-and-translations
+#. XSS in ``react-intl``: https://docs.openedx.org/en/latest/developers/references/developer_guide/preventing_xss/preventing_xss_in_react.html
 
 #. Micro-frontend i18n How To: https://github.com/openedx/frontend-platform/blob/master/docs/how_tos/i18n.rst
 

--- a/oeps/archived/oep-0006-arch-context-xblock-fields.rst
+++ b/oeps/archived/oep-0006-arch-context-xblock-fields.rst
@@ -49,7 +49,7 @@ with particular environment(s) and user(s). A field's ``Scope`` is generally a
 composite property, defined as the combination of a ``BlockScope``, a
 ``UserScope``, and a ``name``.
 
-.. _scopes: https://edx.readthedocs.io/projects/xblock/en/latest/fields.html
+.. _scopes: https://docs.openedx.org/projects/xblock/en/latest/fields.html
 
 For reference, the ``UserScope`` can have three values (no changes to these are
 being proposed):
@@ -189,7 +189,7 @@ that define the ``context_settings_view``. Clicking on the name of that XBlock
 would display the HTML fragment and allow the author to edit the context-scoped
 fields.
 
-.. _studio_view: https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/edx_studio.html
+.. _studio_view: https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/edx_platform/edx_studio.html
 
 Context-scoped fields in OLX (Provisional)
 ==========================================
@@ -235,7 +235,7 @@ The reasoning behind the above provisional spec is as follows:
 * ``<xblock-settings>`` is suggested as a wrapper to keep these new XML nodes
   organized and indicate their purpose clearly.
 
-.. _(docs): https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/directory-structure.html#top-level-directory
+.. _(docs): https://docs.openedx.org/en/latest/educators/olx/directory-structure.html#top-level-directory
 
 Rationale
 *********

--- a/oeps/archived/oep-0016-bp-adopt-bootstrap.rst
+++ b/oeps/archived/oep-0016-bp-adopt-bootstrap.rst
@@ -255,8 +255,8 @@ variety of sites in the Open edX community.
 .. _Bootstrap Proof-of-Concept PR: https://github.com/openedx/edx-platform/pull/14834
 .. _Bootstrap RTL Discovery ticket: https://openedx.atlassian.net/browse/FEDX-352
 .. _Bootstrap 4: https://v4-alpha.getbootstrap.com/
-.. _edX accessibility guidelines: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/conventions/accessibility.html
-.. _edX Front End Working Group: https://openedx.atlassian.net/wiki/display/FEDX/Front+End+Working+Group
+.. _edX accessibility guidelines: https://docs.openedx.org/en/latest/developers/references/a11y-ref.html
+.. _edX Front End Working Group: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3090056949/Frontend+Working+Group
 .. _edX UI Toolkit: http://ui-toolkit.edx.org/
 .. _edX Pattern Library: https://github.com/edx/ux-pattern-library
 .. _OEP-11 - Front End Technology Standards: https://open-edx-proposals.readthedocs.io/en/latest/oep-0011.html

--- a/oeps/best-practices/oep-0017-bp-feature-toggles.rst
+++ b/oeps/best-practices/oep-0017-bp-feature-toggles.rst
@@ -634,7 +634,7 @@ Updated documentation on feature toggles and reporting:
 * See `how to document feature toggles`_.
 * See `how to enable feature toggle reports for an IDA`_.
 
-.. _readthedocs documentation for edx-platform feature toggles: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html
+.. _readthedocs documentation for edx-platform feature toggles: https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html
 .. _annotated toggles in the edx-platform codebase: https://github.com/openedx/edx-platform/search?q=toggle_name
 .. _how to document feature toggles: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html
 .. _grading enhancements: https://github.com/openedx/edx-platform/pull/16082

--- a/oeps/best-practices/oep-0017-bp-feature-toggles.rst
+++ b/oeps/best-practices/oep-0017-bp-feature-toggles.rst
@@ -418,7 +418,7 @@ Eventually, the following classes should be added if/when needed:
   * supports the "Group" toggle type with `Beta Testing`_ for user-provider (enterprise) organization-level overrides.
 
 .. _waffle_utils: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/__init__.py
-.. _how to choose the right toggle class: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/implement_the_right_toggle_type.html#implementing-the-right-toggle-class
+.. _how to choose the right toggle class: https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/implement_the_right_toggle_type.html#implementing-the-right-toggle-class
 
 Req 8: Non-collision
 ~~~~~~~~~~~~~~~~~~~~
@@ -636,11 +636,11 @@ Updated documentation on feature toggles and reporting:
 
 .. _readthedocs documentation for edx-platform feature toggles: https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html
 .. _annotated toggles in the edx-platform codebase: https://github.com/openedx/edx-platform/search?q=toggle_name
-.. _how to document feature toggles: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html
+.. _how to document feature toggles: https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/documenting_new_feature_toggles.html
 .. _grading enhancements: https://github.com/openedx/edx-platform/pull/16082
 .. _user-facing change: https://github.com/openedx/edx-platform/blob/6db93fc791fd2fb52ce705d47320e7868a937587/openedx/features/learner_profile/__init__.py#L13
 .. _course-wide Beta Testing and Opt-outs: https://github.com/openedx/edx-platform/blob/6db93fc791fd2fb52ce705d47320e7868a937587/openedx/features/course_experience/__init__.py#L13-L44
-.. _how to enable feature toggle reports for an IDA: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/adding_new_ida_to_toggle_report.html
+.. _how to enable feature toggle reports for an IDA: https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/adding_new_ida_to_toggle_report.html
 
 Rejected Alternatives
 *********************

--- a/oeps/best-practices/oep-0037-bp-test-data.rst
+++ b/oeps/best-practices/oep-0037-bp-test-data.rst
@@ -92,7 +92,7 @@ The function can take one or more positional arguments if useful for using it in
 .. _rosie: https://www.npmjs.com/package/rosie
 .. _factory-girl: https://www.npmjs.com/package/factory-girl
 .. _SimpleNamespace: https://docs.python.org/3/library/types.html#types.SimpleNamespace
-.. _OLX: https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/index.html
+.. _OLX: https://docs.openedx.org/en/latest/educators/navigation/olx.html
 .. _Faker: https://faker.readthedocs.io/en/stable/
 
 Loading Data


### PR DESCRIPTION
Convert links from edx.readthedocs.io to links on docs.openedx.org

The installing & configuring guide is not yet moved, so those links are currently unchanged. Ref https://github.com/openedx/docs.openedx.org/issues/830

In draft until I figure out what to do with ~~the link to the devdata guide in OEP-26, and~~ the toggles guide in OEP-17
