### PR TITLE
build: Add ref for Sphinx cross-linking

### DIFF
--- a/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
+++ b/oeps/best-practices/oep-0067-bp-tools-and-technology.rst
@@ -79,6 +79,8 @@ This technology is not specific to frontend or backend code.
    tool should be used to perform Continuous Integration (CI) testing for all Open edX repositories
    that perform any sort of software testing.
 
+.. _Frontend Technology Selection:
+
 Frontend Technology Selection
 =============================
 


### PR DESCRIPTION
I'm trying out doing a :ref: link from an intersphinx mapping in the docs.openedx.org repo.

This ref is needed to change the direct ref to OEP-67 in https://raw.githubusercontent.com/openedx/docs.openedx.org/068b045582075feaee7b07ed72d2ab39bd08ad1a/source/developers/references/developer_guide/conventions/frontend.rst to a relative :ref: link using a cross-reference role (https://docs.readthedocs.com/platform/stable/guides/intersphinx.html#using-intersphinx)

IDK I am hoping it works :)
