### PR TITLE
docs: Relax CC requirement for maintaining.

### DIFF
--- a/oeps/processes/oep-0055-proc-project-maintainers.rst
+++ b/oeps/processes/oep-0055-proc-project-maintainers.rst
@@ -219,10 +219,11 @@ In order to be a repository maintainer, you must
   contributions to the project in the last 6 months, such as feature work,
   upgrades, bug fixes, or architectural/design contributions
 * Abide by the Open edX `Code of Conduct`_
-* Be a member of the `Core Contributor Program`_ with rights to the repository
-  in question who has demonstrated excellence in the role of Core Contributor.
-  From time to time, in the case of a strong candidate and project need, core
-  contributor status and maintainer status may be conferred at the same time
+* Be on track to become or already be a member of the `Core Contributor Program`_
+  with rights to the repository in question who has demonstrated excellence in
+  the role of Core Contributor. From time to time, in the case of a strong
+  candidate and project need, core contributor status and maintainer status may
+  be conferred at the same time
 * In the case of repos being moved into the `openedx GitHub organization`_, be
   an original maintainer of the code
 


### PR DESCRIPTION
This can happpen when there is a team that maintains a repo and the team
is adding a new member.  That new member will not have gone through the
CC process yet but will be listed as a maintainer by virtue of being on
the team in the `catalog-info.yaml` file.  Allow for this to be
possible.  In practice we won't run into a lot of issues with this as
long as at least one person on the maintaining team can merge
maintenance work.
