### PR TITLE
docs: OEP-49 Removed deprecated __init__.py section from oep-0049-django...

### DIFF
--- a/oeps/best-practices/oep-0049-django-app-patterns.rst
+++ b/oeps/best-practices/oep-0049-django-app-patterns.rst
@@ -66,20 +66,6 @@ Each app should contain a README.rst to explain its use. See full details of wha
 
 .. _OEP-0019: https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html#readmes
 
-.. _`__init__.py`:
-
-__init__.py
-===========
-
-The ``__init__.py`` file should contain a line for the ``default_app_config`` for the app. This ``default_app_config`` should point to the ``AppConfig`` located in ``<app_name>/apps.py``. It may also contain small app details such as a version. However, unlike many packages, ``__init__.py`` should *not* be used to as the way to export the app's public methods. These should be exported using ``api.py`` (and thus imported as ``from path.to.app.api import public_function``). See api.py_ below.
-
-Example
--------
-
-.. code-block:: python
-
-  default_app_config = "service_name.apps.app_name.apps.CustomAppConfig"
-
 .. _apps.py:
 
 apps.py


### PR DESCRIPTION
Removed the mentioned __init__.py section. Let me know if this task requiring further action.