### PR TITLE
chore: Add cross-references to the OEP index page

### DIFF
--- a/oeps/best-practices/oep-0019-bp-developer-documentation.rst
+++ b/oeps/best-practices/oep-0019-bp-developer-documentation.rst
@@ -113,7 +113,7 @@ OEPs
 .. _OEP-1: https://open-edx-proposals.readthedocs.io/en/latest/oep-0001.html
 .. _edX Architecture team: https://openedx.atlassian.net/wiki/spaces/AC/pages/439353453/Architecture+Team
 
-.. _Architecture Decision Record (ADR):
+.. _ADRs:
 
 ADRs
 ----

--- a/oeps/best-practices/oep-0042-bp-authentication.rst
+++ b/oeps/best-practices/oep-0042-bp-authentication.rst
@@ -207,7 +207,7 @@ Standardized Libraries and Utilities
 
 This section details a variety of authentication related libraries and utilities that Open edX has standardized on. It is important to keep to these standards in order to help keep Open edX more secure.
 
-For any of the following solutions, it is important to avoid creating local alternatives inside an IDA. If a local alternative exists, it should either be deprecated and replaced by these standards, or requires an :ref:`Architecture Decision Record (ADR)` explaining why the exception is necessary and how the security of Open edX will continue to be ensured.
+For any of the following solutions, it is important to avoid creating local alternatives inside an IDA. If a local alternative exists, it should either be deprecated and replaced by these standards, or requires an :ref:`ADRs` explaining why the exception is necessary and how the security of Open edX will continue to be ensured.
 
 API Providers: Authentication Classes
 -------------------------------------
@@ -230,7 +230,7 @@ The following are all DRF Authentication classes.
      - Deprecated
    * - `BasicAuthentication`_ (django-rest-framework)
      - * Exceptions Only
-       * Requires an :ref:`Architecture Decision Record (ADR)` explaining why it is required.
+       * Requires an :ref:`ADRs` explaining why it is required.
 
 Note: Our JwtAuthentication class is a subclass of JSONWebTokenAuthentication, which can be found in `drf-jwt`_, an open source fork of django-rest-framework-jwt that supports Django 2.2.
 

--- a/oeps/index.rst
+++ b/oeps/index.rst
@@ -17,6 +17,8 @@ archive of large and broadly relevant choices made for the platform.
 OEPs
 ****
 
+.. _Processes:
+
 Processes
 =========
 
@@ -28,6 +30,8 @@ OEPs that relate to processes we want to put in place for the Open edX community
    :caption: Processes
 
    processes/oep-*
+
+.. _Best-Practices:
 
 Best Practices
 ==============
@@ -43,6 +47,8 @@ you have a good reason not to.
 
    best-practices/oep-*
 
+.. _Architectural-Decisions:
+
 Architectural Decisions
 =======================
 
@@ -56,6 +62,8 @@ is no clear code repository where they should reside.
    :caption: Architectural Decisions
 
    architectural-decisions/oep-*
+
+.. _Archived-Proposals:
 
 Archived Proposals
 ==================


### PR DESCRIPTION
So we can cross-reference within intersphinx docs
