### PR TITLE
docs: Add crossreference for docs linking

### DIFF
--- a/oeps/best-practices/oep-0066/Open_edX_Auth_Overview_Table.rst
+++ b/oeps/best-practices/oep-0066/Open_edX_Auth_Overview_Table.rst
@@ -1,3 +1,5 @@
+.. _Open edX Auth Overview Table:
+
 Open edX Auth Overview Table
 ----------------------------
 .. list-table:: 


### PR DESCRIPTION
Adding cross-references to the docs, rather than referencing the HTML page directly, allows us to have more robust cross linking that is safe from filename/path changes (ofc provided no one changes the name of the ref!)